### PR TITLE
fix: support relative parent paths

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -67,7 +67,7 @@ export async function generateWasmModule(
                     : `if (typeof module === 'string') {
 
                 // Resolve relative urls from the runtime script path
-                if (module.startsWith('./')) {
+                if (module.startsWith('./') || module.startsWith('../')) {
                     module = new URL(module, import.meta.url).href
                 }
 


### PR DESCRIPTION
This ended up being relevant for a project of mine.

Context:

My esbuild config includes
```js
   {
      ...
      platform: "browser",
      bundle: true,
      entryPoints: [
         "src/program.js"
      ],
      plugins: [
        ...
        wasmLoader({
          mode: "deferred",
        }),
        ...
      ],
      outdir: "public/app/",
      target: "esnext",
      format: "esm",
      assetNames: "assets/[name]--hash-[hash]",
      ...
   }
```

and my import was in `src/foo/loader.js`
```js
import { fn } from "./bar.wasm"
...
```

The .wasm file ends up at
`public/app/assets/bar--hash-AAAA.wasm`

and `loadWasm` was being called with `module` as `"../assets/bar--hash-AAAA.wasm"`

This is despite wasm-loader/module.ts generating this import:
```js
import wasmModule from "/home/willheslam/project/src/foo/bar.wasm"
```

I think the relative parent path is because my JS files are put into "public/app/src" rather than "public/app" - this wouldn't normally be the case, but I included some extra entry files outside of "src", and esbuild has slightly surprising behaviour - but understandable, to prevent conflicts - it finds the nearest common parent of all the included entry points and uses that as the base dir inside your outdir as detailed here:
https://esbuild.github.io/api/#outdir
hence the ".." to get back to public/app/ instead of just "./"
which started causing this plugin to break.